### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,6 @@
 name: Vercel Preview Deployment
+permissions:
+  contents: read
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
Potential fix for [https://github.com/DPhngNam/HuongQue/security/code-scanning/1](https://github.com/DPhngNam/HuongQue/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's operations, it does not appear to need write access to the repository or other sensitive permissions. The minimal required permission is likely `contents: read`, which allows the workflow to read repository contents if necessary. This will ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
